### PR TITLE
Refactor platform_config get method to return Platform instance

### DIFF
--- a/core/platform_config.py
+++ b/core/platform_config.py
@@ -88,17 +88,16 @@ class PlatformsConfig(BaseModel):
             return [v]
         return v
 
-    def get(self, platform_id: str) -> Platform | None:
-        return self.platforms.get(platform_id)
+    def get(self, platform_id: str) -> Platform:
+        return self.platforms.get(platform_id, Platform())
 
     def roll_cookie(self, platform_id: str) -> str | None:
-        if not (pc := self.get(platform_id)):
-            return None
+        pc = self.get(platform_id)
         return pc.roll_cookie()
 
     def roll_parser_proxy(self, platform_id: str) -> str | None:
-        if not (pc := self.get(platform_id)):
-            return None
+        pc = self.get(platform_id)
+
         if pc.disable_parser_proxy:
             return None
 
@@ -109,8 +108,8 @@ class PlatformsConfig(BaseModel):
         return None
 
     def roll_downloader_proxy(self, platform_id: str) -> str | None:
-        if not (pc := self.get(platform_id)):
-            return None
+        pc = self.get(platform_id)
+
         if pc.disable_downloader_proxy:
             return None
 


### PR DESCRIPTION
Update the `get` method to return a `Platform` instance by default, removing the need for redundant null value checks throughout the codebase.

- Ensures `get` always returns a valid `Platform` instance
- Removes unnecessary null checking logic  
- Improves type safety and code clarity

## Summary by Sourcery

重构平台配置的访问方式，使得在获取平台时始终返回非空的 `Platform` 实例，下游逻辑无需再执行显式的空值检查。

改进内容：
- 更新 `platform_config.get`，在缺少平台 ID 时返回默认的 `Platform` 实例，确保调用方始终能获得一个 `Platform` 对象。
- 简化 cookie 和代理轮换方法，使其依赖非空的 `Platform` 返回值，而不再执行多余的存在性检查。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Refactor platform configuration access so that retrieving a platform always yields a non-null Platform instance and downstream logic no longer performs explicit null checks.

Enhancements:
- Update platform_config.get to return a default Platform instance when a platform ID is missing, ensuring callers always receive a Platform object.
- Simplify cookie and proxy rolling methods to rely on the non-null Platform return value instead of performing redundant existence checks.

</details>