### PR TITLE
🐛 修复(platform_config): 修正 get 方法返回类型为 Optional 并显式处理平台不存在场景

### DIFF
--- a/core/platform_config.py
+++ b/core/platform_config.py
@@ -88,16 +88,17 @@ class PlatformsConfig(BaseModel):
             return [v]
         return v
 
-    def get(self, platform_id: str) -> Platform:
-        return self.platforms.get(platform_id, Platform())
+    def get(self, platform_id: str) -> Platform | None:
+        return self.platforms.get(platform_id)
 
     def roll_cookie(self, platform_id: str) -> str | None:
-        pc = self.get(platform_id)
+        if not (pc := self.get(platform_id)):
+            return None
         return pc.roll_cookie()
 
     def roll_parser_proxy(self, platform_id: str) -> str | None:
-        pc = self.get(platform_id)
-
+        if not (pc := self.get(platform_id)):
+            pc = Platform()
         if pc.disable_parser_proxy:
             return None
 
@@ -108,8 +109,8 @@ class PlatformsConfig(BaseModel):
         return None
 
     def roll_downloader_proxy(self, platform_id: str) -> str | None:
-        pc = self.get(platform_id)
-
+        if not (pc := self.get(platform_id)):
+            pc = Platform()
         if pc.disable_downloader_proxy:
             return None
 


### PR DESCRIPTION
## Summary by Sourcery

Bug Fixes:
- 将 `platform_config.get` 修改为在遇到未知平台时返回 `None`，并更新 cookie/代理轮换方法，以便在处理不存在的平台时能够正确处理，而不会返回非预期的默认值。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Bug Fixes:
- Change platform_config.get to return None for unknown platforms and update cookie/proxy rolling methods to correctly handle non-existent platforms without returning unintended defaults.

</details>